### PR TITLE
sprocketsからpropshaftへ移行

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -117,7 +117,7 @@
 ## アセットパイプライン
 - jsbundling-rails
 - cssbundling-rails
-- sprockets-rails
+- propshaft
 - esbuild
 
 ## バックエンド

--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,9 @@ source "https://rubygems.org"
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.2.2"
-# The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
-gem "sprockets-rails"
+# The new asset pipeline for Rails [https://github.com/rails/propshaft]
+gem "propshaft"
+
 # Use postgresql as the database for Active Record
 gem "pg", "~> 1.1"
 # Use the Puma web server [https://github.com/puma/puma]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -247,6 +247,11 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.5.9)
+    propshaft (1.1.0)
+      actionpack (>= 7.0.0)
+      activesupport (>= 7.0.0)
+      rack
+      railties (>= 7.0.0)
     pry (0.15.0)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -389,13 +394,6 @@ GEM
     spring (4.2.1)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
-    sprockets (4.2.1)
-      concurrent-ruby (~> 1.0)
-      rack (>= 2.2.4, < 4)
-    sprockets-rails (3.5.2)
-      actionpack (>= 6.1)
-      activesupport (>= 6.1)
-      sprockets (>= 3.0.0)
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.1.2)
@@ -455,6 +453,7 @@ DEPENDENCIES
   omniauth-google-oauth2
   omniauth-rails_csrf_protection
   pg (~> 1.1)
+  propshaft
   pry-byebug
   pry-rails
   puma (>= 5.0)
@@ -467,7 +466,6 @@ DEPENDENCIES
   selenium-webdriver
   shoulda-matchers
   spring-commands-rspec
-  sprockets-rails
   stimulus-rails
   turbo-rails
   web-console

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,3 +1,0 @@
-//= link_tree ../images
-//= link_tree ../builds
-

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,11 +1,10 @@
 // Entry point for the build script in your package.json
-import { Turbo } from "@hotwired/turbo-rails"
+import * as Turbo from '@hotwired/turbo-rails';
 window.Turbo = Turbo;
 
-import { Application } from "@hotwired/stimulus"
-import { registerControllers } from './controllers'
-
-import ChartController from './controllers/chart_controller'
+import { Application } from '@hotwired/stimulus';
+import { registerControllers } from './controllers';
+import ChartController from './controllers/chart_controller';
 
 const application = Application.start();
 registerControllers(application);

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -3,6 +3,3 @@
 // ./bin/rails generate stimulus controllerName
 
 import { application } from './application';
-import HelloController from './hello_controller';
-
-application.register('hello', HelloController);

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -9,9 +9,13 @@
 <%# PNGファビコン - レガシーブラウザのフォールバック用 %>
 <%= favicon_link_tag 'logo/favicon.png', type: 'image/png' %>
 
+<%# CDNスクリプト %>
+<script src="https://unpkg.com/@hotwired/turbo-rails@8.0.0-beta.2/dist/turbo.es2017-esm.js" type="module"></script>
+<script src="https://unpkg.com/@hotwired/stimulus@3.2.2/dist/stimulus.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/apexcharts@3.45.0/dist/apexcharts.min.js"></script>
+
 <%# スタイルシートとJavaScript %>
 <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
 <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
 
 <%= display_meta_tags(default_meta_tags) %>
-

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -46,9 +46,6 @@ Rails.application.configure do
   config.action_mailer.raise_delivery_errors = false
   config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
 
-  # アセットのホスト設定を追加
-  config.asset_host = "http://localhost:3000"
-  Rails.application.routes.default_url_options = { host: "localhost", port: 3000 }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
@@ -67,12 +64,6 @@ Rails.application.configure do
 
   # Highlight code that enqueued background job in logs.
   config.active_job.verbose_enqueue_logs = true
-
-  # Suppress logger output for asset requests.
-  config.assets.quiet = true
-
-  # 開発環境ではassetsのprefixをdev-assetsにする(assetsの変更がブラウザに反映されるようにする)
-  config.assets.prefix = "/dev-assets"
 
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -10,13 +10,3 @@ Rails.application.config.assets.version = "1.0"
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
 # Rails.application.config.assets.precompile += %w[ admin.js admin.css ]
-
-# アセットパイプラインの設定
-# JavaScriptファイルのパスを追加
-Rails.application.config.assets.paths << Rails.root.join("app/javascript")
-
-# Nexus関連のスタイルシートのパスを追加
-Rails.application.config.assets.paths << Rails.root.join("app/assets/stylesheets")
-
-# application.js をプリコンパイル対象に含める
-Rails.application.config.assets.precompile += %w[ application.js ]

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -4,22 +4,24 @@
 # See the Securing Rails Applications Guide for more information:
 # https://guides.rubyonrails.org/security.html#content-security-policy-header
 
-# Rails.application.configure do
-#   config.content_security_policy do |policy|
-#     policy.default_src :self, :https
-#     policy.font_src    :self, :https, :data
-#     policy.img_src     :self, :https, :data
-#     policy.object_src  :none
-#     policy.script_src  :self, :https
-#     policy.style_src   :self, :https
-#     # Specify URI for violation reports
-#     # policy.report_uri "/csp-violation-report-endpoint"
-#   end
-#
-#   # Generate session nonces for permitted importmap, inline scripts, and inline styles.
-#   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-#   config.content_security_policy_nonce_directives = %w(script-src style-src)
-#
-#   # Report violations without enforcing the policy.
-#   # config.content_security_policy_report_only = true
-# end
+Rails.application.configure do
+  config.content_security_policy do |policy|
+    policy.default_src :self, :https
+    policy.font_src    :self, :https, :data
+    policy.img_src     :self, :https, :data
+    policy.object_src  :none
+    policy.script_src  :self, :https, 'https://unpkg.com', 'https://cdn.jsdelivr.net'
+    # nonceを使用する代わりにunsafe-inlineを使用
+    policy.style_src   :self, :https, :unsafe_inline
+    policy.connect_src :self, :https
+    policy.frame_ancestors :none
+    policy.base_uri    :self
+  end
+
+  # nonceの生成を無効化
+  # config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
+  # config.content_security_policy_nonce_directives = %w(script-src style-src)
+
+  # 開発中はCSP違反をレポートモードで確認できます
+  config.content_security_policy_report_only = true
+end

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "tailwindcss": "^3.4.1"
   },
   "scripts": {
-    "build": "esbuild app/javascript/*.* --bundle --sourcemap --outdir=app/assets/builds --public-path=/assets --format=esm",
-    "build:watch": "esbuild app/javascript/*.* --bundle --sourcemap --outdir=app/assets/builds --public-path=/assets --format=esm --watch",
+    "build": "esbuild app/javascript/*.* --bundle --sourcemap --outdir=app/assets/builds --public-path=/assets --format=esm --external:@hotwired/turbo-rails --external:@hotwired/stimulus --external:apexcharts",
+    "build:watch": "esbuild app/javascript/*.* --bundle --sourcemap --outdir=app/assets/builds --public-path=/assets --format=esm --external:@hotwired/turbo-rails --external:@hotwired/stimulus --external:apexcharts --watch",
     "build:css": "tailwindcss -i ./app/assets/stylesheets/application.tailwind.css -o ./app/assets/builds/application.css --minify",
     "build:css:watch": "tailwindcss -i ./app/assets/stylesheets/application.tailwind.css -o ./app/assets/builds/application.css --watch"
   },


### PR DESCRIPTION
## 前回からの変更点 

### SprocketsからPropshaftへの変更
- Gemfileの修正
- 不要なファイルの削除（manifest.js）
- application.jsのフォーマット変更   

### アセットの一部をCDN配信へ変更
- package.jsonにてyarn build時に依存関係がでるものを外部依存に変更
- config/initializers/content_security_policy.rb, _head.html.erb へ追加処理

## エラー状況  

前述の変更後に次のコマンドを実施しました。

```shell
rm -rf node_modules/

# ビルド成果物を削除
rm -rf app/assets/builds/

# yarn.lockを削除（必要な場合）
rm yarn.lock

# Yarnのキャッシュをクリア
yarn cache clean

# 依存関係を再インストール
yarn install

# アセットを再ビルド
yarn build

docker compose down -v
docker compose up -d
``` 

しかしながら、ブラウザ上では同じエラーが依然として発生しています。

```javascript
Uncaught TypeError: Failed to resolve module specifier "@hotwired/turbo-rails". Relative references must start with either "/", "./", or "../".
``` 